### PR TITLE
Make commenting contextual

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/cfscript.configuration.json
+++ b/cfscript.configuration.json
@@ -1,6 +1,7 @@
 {
 	"comments": {
-		"blockComment": [ "<!---", "--->" ]
+		"lineComment": "//",
+		"blockComment": [ "/*", "*/" ]
 	},
 	"brackets": [
 		["{", "}"],

--- a/cfscript.configuration.json
+++ b/cfscript.configuration.json
@@ -1,6 +1,5 @@
 {
 	"comments": {
-		"lineComment": [ "<!---", "--->" ],
 		"blockComment": [ "<!---", "--->" ]
 	},
 	"brackets": [

--- a/extension.js
+++ b/extension.js
@@ -1,0 +1,123 @@
+// https://github.com/trstt/cfml-comment-tags
+
+// or, could just try to merge with This
+// https://github.com/ilich/vscode-coldfusion
+
+// The module 'vscode' contains the VS Code extensibility API
+// Import the module and reference it with the alias vscode in your code below
+const vscode = require('vscode');
+
+function activate(context) {
+  let disposable = vscode.commands.registerCommand(
+    'extension.cfml-comment-tags',
+    function() {
+      // The code you place here will be executed every time your command is executed
+      var editor = vscode.window.activeTextEditor;
+
+      // set cfscript config by default
+      let languageConfig = {
+        comments: {
+          lineComment: '//',
+          blockComment: ['/*', '*/']
+        },
+        brackets: [['{', '}'], ['[', ']'], ['(', ')']],
+        autoClosingPairs: [
+          {
+            open: '{',
+            close: '}'
+          },
+          {
+            open: '[',
+            close: ']'
+          },
+          {
+            open: '(',
+            close: ')'
+          },
+          {
+            open: '#',
+            close: '#'
+          },
+          {
+            open: "'",
+            close: "'",
+            notIn: ['string', 'comment']
+          },
+          {
+            open: '"',
+            close: '"',
+            notIn: ['string']
+          },
+          {
+            open: '/**',
+            close: ' */',
+            notIn: ['string']
+          }
+        ],
+        surroundingPairs: [
+          ['{', '}'],
+          ['[', ']'],
+          ['(', ')'],
+          ["'", "'"],
+          ['#', '#'],
+          ['"', '"']
+        ]
+      };
+
+      try {
+        if (editor != undefined) {
+          const selection = editor.selection;
+          const textBeforeSelection = editor.document.getText(
+            new vscode.Range(new vscode.Position(0, 0), selection.start)
+          );
+          // if no <cf> tags, assume cfscript
+          // console.log(
+          //   textBeforeSelection
+          //   .replace(editor.document.eol === 1 ? /\n/gm : /\n\r/gm, '')
+          //   .match(/\<cf(?!.*\<cf).{6}/g)[0],
+          //   textBeforeSelection
+          //   .replace(editor.document.eol === 1 ? /\n/gm : /\n\r/gm, '')
+          //   .search(/\<\/cfscript/g)
+          //   // ,textBeforeSelection.replace(editor.document.eol == 1 ? /\n/ : /\n\r/, ''),
+          //   // editor.document.eol
+          // );
+          if (
+            // <cf tag exists
+            textBeforeSelection.search(/\<cf/) !== -1 &&
+            // the last instance is not <cfscript
+            (textBeforeSelection
+              .replace(editor.document.eol === 1 ? /\n/gm : /\n\r/gm, '')
+              .match(/\<cf(?!.*\<cf).{6}/g)[0] !== '<cfscript' ||
+              // there is a cfscript tag above you
+              textBeforeSelection
+                .replace(editor.document.eol === 1 ? /\n/gm : /\n\r/gm, '')
+                .search(/\<\/cfscript/g) !== -1 ||
+              // selection contains "<cfscript> or </cfscript>"
+              editor.document
+                .getText(editor.selection.line)
+                .search(/<\/?cfscript/) !== -1)
+          ) {
+            languageConfig = Object.assign(languageConfig, {
+              comments: {
+                blockComment: ['<!---', '--->']
+              }
+            });
+          }
+          // set language config, which should enable the right kind of comments
+          vscode.languages.setLanguageConfiguration(
+            'lang-cfml',
+            languageConfig
+          );
+          vscode.commands.executeCommand('editor.action.commentLine');
+        }
+      } catch (e) {
+        console.log(e);
+      }
+    }
+  );
+}
+exports.activate = activate;
+
+// this method is called when your extension is deactivated
+function deactivate() {}
+exports.deactivate = deactivate;

--- a/extension.js
+++ b/extension.js
@@ -1,20 +1,20 @@
-// https://github.com/trstt/cfml-comment-tags
-
-// or, could just try to merge with This
-// https://github.com/ilich/vscode-coldfusion
-
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
 const vscode = require('vscode');
 
+/**
+ * Determine code context on ColdFusion files to determine whether to use
+ * tag-style comments or cfscript-style comments.
+ * 
+ * Uses a simple regex to determine if cf tags are present, and if so
+ * whether the selection is within a cfscript tag.
+ */
 function activate(context) {
   let disposable = vscode.commands.registerCommand(
     'extension.cfml-comment-tags',
     function() {
-      // The code you place here will be executed every time your command is executed
       var editor = vscode.window.activeTextEditor;
 
-      // set cfscript config by default
+      // define cfscript config
+      // taken from ./cfscript.configuration.json
       let languageConfig = {
         comments: {
           lineComment: '//',
@@ -22,37 +22,13 @@ function activate(context) {
         },
         brackets: [['{', '}'], ['[', ']'], ['(', ')']],
         autoClosingPairs: [
-          {
-            open: '{',
-            close: '}'
-          },
-          {
-            open: '[',
-            close: ']'
-          },
-          {
-            open: '(',
-            close: ')'
-          },
-          {
-            open: '#',
-            close: '#'
-          },
-          {
-            open: "'",
-            close: "'",
-            notIn: ['string', 'comment']
-          },
-          {
-            open: '"',
-            close: '"',
-            notIn: ['string']
-          },
-          {
-            open: '/**',
-            close: ' */',
-            notIn: ['string']
-          }
+          { open: '{', close: '}' },
+          { open: '[', close: ']' },
+          { open: '(', close: ')' },
+          { open: '#', close: '#' },
+          { open: "'", close: "'", notIn: ['string', 'comment'] },
+          { open: '"', close: '"', notIn: ['string'] },
+          { open: '/**', close: ' */', notIn: ['string'] }
         ],
         surroundingPairs: [
           ['{', '}'],
@@ -64,60 +40,45 @@ function activate(context) {
         ]
       };
 
-      try {
-        if (editor != undefined) {
-          const selection = editor.selection;
-          const textBeforeSelection = editor.document.getText(
-            new vscode.Range(new vscode.Position(0, 0), selection.start)
-          );
-          // if no <cf> tags, assume cfscript
-          // console.log(
-          //   textBeforeSelection
-          //   .replace(editor.document.eol === 1 ? /\n/gm : /\n\r/gm, '')
-          //   .match(/\<cf(?!.*\<cf).{6}/g)[0],
-          //   textBeforeSelection
-          //   .replace(editor.document.eol === 1 ? /\n/gm : /\n\r/gm, '')
-          //   .search(/\<\/cfscript/g)
-          //   // ,textBeforeSelection.replace(editor.document.eol == 1 ? /\n/ : /\n\r/, ''),
-          //   // editor.document.eol
-          // );
-          if (
-            // <cf tag exists
-            textBeforeSelection.search(/\<cf/) !== -1 &&
-            // the last instance is not <cfscript
-            (textBeforeSelection
-              .replace(editor.document.eol === 1 ? /\n/gm : /\n\r/gm, '')
-              .match(/\<cf(?!.*\<cf).{6}/g)[0] !== '<cfscript' ||
-              // there is a cfscript tag above you
-              textBeforeSelection
-                .replace(editor.document.eol === 1 ? /\n/gm : /\n\r/gm, '')
-                .search(/\<\/cfscript/g) !== -1 ||
-              // selection contains "<cfscript> or </cfscript>"
-              editor.document
-                .getText(editor.selection.line)
-                .search(/<\/?cfscript/) !== -1)
-          ) {
-            languageConfig = Object.assign(languageConfig, {
-              comments: {
-                blockComment: ['<!---', '--->']
-              }
-            });
-          }
-          // set language config, which should enable the right kind of comments
-          vscode.languages.setLanguageConfiguration(
-            'lang-cfml',
-            languageConfig
-          );
-          vscode.commands.executeCommand('editor.action.commentLine');
+      if (editor != undefined) {
+        const selection = editor.selection;
+        const textBeforeSelection = editor.document.getText(
+          new vscode.Range(new vscode.Position(0, 0), selection.start)
+        );
+        const fullSelectionText = editor.document.getText(
+          new vscode.Range(
+            new vscode.Position(editor.selection.start.line, 0),
+            editor.document.lineAt(editor.selection.end).range.end
+          )
+        );
+
+        // if no <cf> tags, assume cfscript
+        // if text is within a <cfscript> tag, default to cfscript comments
+        if (
+          // <cf tag exists, and
+          textBeforeSelection.search(/\<cf/) !== -1 &&
+          // selection contains "<cfscript or </cfscript", or
+          (fullSelectionText.search(/<\/?cfscript/) !== -1 ||
+            // the last instance of <cf or </cf is not <cfscript.
+            // (If the last instance is cfscript, it means we are within a cfscript tag
+            // and should use cfscript comments.)
+            textBeforeSelection
+              .match(/\<\/?cf(?!.*\<\/?cf).{0,6}/g)
+              .reverse()[0] !== '<cfscript')
+        ) {
+          languageConfig = Object.assign(languageConfig, {
+            comments: {
+              blockComment: ['<!---', '--->']
+            }
+          });
         }
-      } catch (e) {
-        console.log(e);
+        // set language config, which should enable the right kind of comments
+        vscode.languages.setLanguageConfiguration('lang-cfml', languageConfig);
+        vscode.commands.executeCommand('editor.action.commentLine');
       }
     }
   );
 }
 exports.activate = activate;
 
-// this method is called when your extension is deactivated
-function deactivate() {}
-exports.deactivate = deactivate;
+exports.deactivate = function() {};

--- a/matchers.js
+++ b/matchers.js
@@ -1,0 +1,28 @@
+// <cf tag exists
+function containsCFTag(text) {
+  return text.search(/\<\/?cf/) !== -1;
+}
+
+// selection contains "<cfscript or </cfscript"
+function containsCFScriptTag(text) {
+  return text.search(/<\/?cfscript/) !== -1;
+}
+
+// Check if the last instance of <cf or </cf is <cfscript.
+function isLastTagCFScript(text) {
+  return text.match(/\<\/?cf(?!.*\<\/?cf).{0,6}/g).reverse()[0] === '<cfscript';
+}
+
+function isTagComment(beforeSelection, selection) {
+  return (
+    containsCFTag(beforeSelection) &&
+    (containsCFScriptTag(selection) || !isLastTagCFScript(beforeSelection))
+  );
+}
+
+module.exports = {
+  containsCFTag: containsCFTag,
+  containsCFScriptTag: containsCFScriptTag,
+  isLastTagCFScript: isLastTagCFScript,
+  isTagComment: isTagComment
+};

--- a/matchers.js
+++ b/matchers.js
@@ -10,13 +10,29 @@ function containsCFScriptTag(text) {
 
 // Check if the last instance of <cf or </cf is <cfscript.
 function isLastTagCFScript(text) {
-  return text.match(/\<\/?cf(?!.*\<\/?cf).{0,6}/g).reverse()[0] === '<cfscript';
+  // sometimes text.match().reverse() fails due to "reverse"
+  // opinion: default behavior should be cfscript style comment, default result to "true"
+  var result = true;
+  try {
+    result =
+      text.match(/\<\/?cf(?!.*\<\/?cf).{0,6}/g).reverse()[0] === '<cfscript';
+  } catch (e) {}
+  return result;
 }
 
-function isTagComment(beforeSelection, selection) {
+/**
+ * Returns true if the comment should use tag style comments, otherwise false.
+ * @param {string} docText
+ * @param {string} beforeSelection 
+ * @param {string} selection 
+ * @param {number} line 
+ */
+function isTagComment(docText, beforeSelection, selection, line) {
   return (
-    containsCFTag(beforeSelection) &&
-    (containsCFScriptTag(selection) || !isLastTagCFScript(beforeSelection))
+    containsCFTag(docText) &&
+    (line === 0 ||
+      containsCFScriptTag(selection) ||
+      !isLastTagCFScript(beforeSelection))
   );
 }
 

--- a/package.json
+++ b/package.json
@@ -20,15 +20,31 @@
 		"Languages"
 	],
 	"activationEvents": [
-			"onCommand:extension.cfml-comment-tags"
+		"onCommand:extension.cfml-line-comment",
+		"onCommand:extension.cfml-block-comment"
 	],
 	"main": "./extension",
 	"contributes": {
 		"languages": [
-			{ "id": "lang-cfml", "aliases": ["CFML"], "extensions": [".cfm",".cfml",".cfc"], "configuration": "./cfscript.configuration.json"}
+			{
+				"id": "lang-cfml",
+				"aliases": [
+					"CFML"
+				],
+				"extensions": [
+					".cfm",
+					".cfml",
+					".cfc"
+				],
+				"configuration": "./cfscript.configuration.json"
+			}
 		],
 		"grammars": [
-			{"language": "lang-cfml", "scopeName": "embedding.cfml", "path": "./syntaxes/cfml.tmLanguage" }
+			{
+				"language": "lang-cfml",
+				"scopeName": "embedding.cfml",
+				"path": "./syntaxes/cfml.tmLanguage"
+			}
 		],
 		"snippets": [
 			{
@@ -37,18 +53,34 @@
 			}
 		],
 		"commands": [
-				{
-					"command": "extension.cfml-comment-tags",
-					"title": "Wrap in or add Coldfusion comment tags"
-				}
-			],
+			{
+				"command": "extension.cfml-line-comment",
+				"title": "ColdFusion line comment"
+			},
+			{
+				"command": "extension.cfml-block-comment",
+				"title": "ColdFusion block comment"
+			}
+		],
 		"keybindings": [
 			{
-				"command": "extension.cfml-comment-tags",
+				"command": "extension.cfml-line-comment",
 				"key": "ctrl+/",
 				"mac": "cmd+/",
-				"when": "editorTextFocus && editorLangId == lang-cfml"
+				"when": "editorTextFocus && !editorReadnly && editorLangId == lang-cfml"
+			},
+			{
+				"command": "extension.cfml-block-comment",
+				"key": "shift+alt+a",
+				"mac": "shift+alt+a",
+				"when": "editorTextFocus && !editorReadnly && editorLangId == lang-cfml"
 			}
 		]
+	},
+	"scripts": {
+		"test": "mocha"
+	},
+	"devDependencies": {
+		"mocha": "^3.5.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
 	"categories": [
 		"Languages"
 	],
+	"activationEvents": [
+			"onCommand:extension.cfml-comment-tags"
+	],
+	"main": "./extension",
 	"contributes": {
 		"languages": [
 			{ "id": "lang-cfml", "aliases": ["CFML"], "extensions": [".cfm",".cfml",".cfc"], "configuration": "./cfscript.configuration.json"}
@@ -30,6 +34,20 @@
 			{
 				"language": "lang-cfml",
 				"path": "./snippets/snippets.json"
+			}
+		],
+		"commands": [
+				{
+					"command": "extension.cfml-comment-tags",
+					"title": "Wrap in or add Coldfusion comment tags"
+				}
+			],
+		"keybindings": [
+			{
+				"command": "extension.cfml-comment-tags",
+				"key": "ctrl+/",
+				"mac": "cmd+/",
+				"when": "editorTextFocus && editorLangId == lang-cfml"
 			}
 		]
 	}

--- a/test/matchers.test.js
+++ b/test/matchers.test.js
@@ -1,0 +1,303 @@
+const assert = require('assert');
+const {
+  containsCFTag,
+  containsCFScriptTag,
+  isLastTagCFScript,
+  isTagComment
+} = require('../matchers');
+
+describe('containsCFTag', function() {
+  it('should return false if no <cf> tags exist', function() {
+    let string = `component {
+                        public void function foo() {
+                            WriteOutput("Method foo() called<br/>");
+                        }
+
+                        public function getString() {
+                            var x = "hello";
+                            return x;
+                        }
+                    }`;
+    assert.equal(
+      containsCFTag(string),
+      false,
+      'incorrectly found a <cf> tag in component definition'
+    );
+
+    string = `function Sum(a, b) {
+            var sum = a + b;
+            return sum;
+        }`;
+    assert.equal(
+      containsCFTag(string),
+      false,
+      'incorrectly found a <cf> tag in function definition'
+    );
+  });
+
+  it('should return true if <cf> tags exist', function() {
+    let string = `<cfif IsDefined("form.myValue")> 
+                        <cfif IsNumeric(form.myValue)> 
+                            <cfset x = form.myValue> 
+                            <cfscript> 
+                                y = x; 
+                                z = 2 * y; 
+                                StringVar = form.myString; 
+                            </cfscript> 
+                        <cfoutput>        <p>twice #x# is #z#. 
+                            <p>Your string value was: <b><I>#StringVar#</i></b>    </cfoutput> 
+                    <cfelse>`;
+    assert.equal(containsCFTag(string), true, 'did not find <cf> tag');
+
+    string = `if IsNumeric(form.myValue)> 
+                    <cfs`;
+    assert.equal(
+      containsCFTag(string),
+      true,
+      'did not find <cf> tag in partial string'
+    );
+
+    string = `        <p>twice #x# is #z#. 
+        <p>Your string value was: <b><I>#StringVar#</i></b>    </cfoutput>`;
+    assert.equal(
+      containsCFTag(string),
+      true,
+      'did not find <cf> tag when only matching tags were closing tags'
+    );
+  });
+});
+
+describe('containsCFScriptTag', function() {
+  it('should return false if no cf tags are present', function() {
+    let string = `function Sum(a, b) {
+            var sum = a + b;
+            return sum;
+        }`;
+    assert.equal(
+      containsCFScriptTag(string),
+      false,
+      'incorrectly found a <cfscript> tag in function definition'
+    );
+  });
+
+  it('should return false if cf tags are present but no cfscript', function() {
+    let string = `<cfif IsDefined("form.myValue")> 
+                        <cfif IsNumeric(form.myValue)> 
+                            <cfset x = form.myValue> 
+                        <cfoutput>        <p>twice #x# is #z#. 
+                            <p>Your string value was: <b><I>#StringVar#</i></b>    </cfoutput> 
+                    <cfelse>`;
+    assert.equal(
+      containsCFScriptTag(string),
+      false,
+      'found a <cfscript> tag when none was present'
+    );
+  });
+
+  it('should return true if a cfscript tag is present', function() {
+    let string = `<cfif IsDefined("form.myValue")> 
+                        <cfif IsNumeric(form.myValue)> 
+                            <cfset x = form.myValue> 
+                            <cfscript> 
+                                y = x; 
+                                z = 2 * y; 
+                                StringVar = form.myString; 
+                            </cfscript> 
+                        <cfoutput>        <p>twice #x# is #z#. 
+                            <p>Your string value was: <b><I>#StringVar#</i></b>    </cfoutput> 
+                    <cfelse>`;
+    assert.equal(
+      containsCFScriptTag(string),
+      true,
+      'did not find <cfscript> tag in multi-line string'
+    );
+
+    string = `<cfif IsDefined("form.myValue")> 
+                <cfif IsNumeric(form.myValue)> 
+                    <cfset x = form.myValue> 
+                    <cfscript> 
+                        y = x;`;
+    assert.equal(
+      containsCFScriptTag(string),
+      true,
+      'did not find <cfscript> when no closing tag was present'
+    );
+
+    string = `<cfif IsDefined("form.myValue")> <cfif IsNumeric(form.myValue)> <cfset x = form.myValue> <cfscript> y = x;`;
+    assert.equal(
+      containsCFScriptTag(string),
+      true,
+      'did not find <cfscript> in single line string'
+    );
+
+    string = `<cfscript>`;
+    assert.equal(
+      containsCFScriptTag(string),
+      true,
+      'did not find <cfscript> when that was the entire string'
+    );
+  });
+
+  it('should return true if a closing cfscript tag is present', function() {
+    string = `y = x; 
+                        z = 2 * y; 
+                        StringVar = form.myString; 
+                    </cfscript> 
+                <cfoutput>        <p>twice #x# is #z#. 
+                    <p>Your string value was: <b><I>#StringVar#</i></b>    </cfoutput> 
+                <cfelse>`;
+    assert.equal(
+      containsCFScriptTag(string),
+      true,
+      'did not find </cfscript> when no opening tag was present'
+    );
+
+    string = `y = x; z = 2 * y; StringVar = form.myString; </cfscript><cfoutput> <p>twice #x# is #z#. </cfoutput> <cfelse>`;
+    assert.equal(
+      containsCFScriptTag(string),
+      true,
+      'did not find </cfscript> in single line string'
+    );
+
+    string = `</cfscript>`;
+    assert.equal(
+      containsCFScriptTag(string),
+      true,
+      'did not find </cfscript> when that was the entire string'
+    );
+  });
+});
+
+describe('isLastTagCFScript', function() {
+  it('should return false when cfscript tag is not the last tag in the string', function() {
+    let string = `<cfscript>
+                    y = x; 
+                    z = 2 * y; 
+                    StringVar = form.myString; 
+                </cfscript> 
+            <cfoutput>        <p>twice #x# is #z#. 
+                <p>Your string value was: <b><I>#StringVar#</i></b>    </cfoutput> 
+            <cfelse>`;
+    assert.equal(
+      isLastTagCFScript(string),
+      false,
+      'it thought that <cfelse> was a <cfscript> tag'
+    );
+
+    string = `<cfscript>
+                    y = x; 
+                    z = 2 * y; 
+                    StringVar = form.myString; 
+                </cfscript>`;
+    assert.equal(
+      isLastTagCFScript(string),
+      false,
+      'it thought that a closing </cfscript> tag was an opening <cfscript> tag'
+    );
+  });
+  it('should return true when cfscript is the last tag in the string', function() {
+    let string = `<cfscript>
+                    y = x; 
+                    z = 2 * y; 
+                    StringVar = form.myString; `;
+    assert.equal(
+      isLastTagCFScript(string),
+      true,
+      'did not recognize the last tag as cfscript when cfscript is the only tag present'
+    );
+
+    string = `<cfif IsDefined("form.myValue")> 
+            <cfif IsNumeric(form.myValue)> 
+                <cfset x = form.myValue> 
+                <cfscript> 
+                    y = x; `;
+    assert.equal(
+      isLastTagCFScript(string),
+      true,
+      'did not recognize last tag as cfscript when other tags exist above it'
+    );
+
+    string = `<cfscript>`;
+    assert.equal(
+      isLastTagCFScript(string),
+      true,
+      'failed to recognize the string "<cfscript>" as the last cf tag'
+    );
+  });
+});
+
+/**
+ * Each test case in this suite should be passed two strings:
+ * 1. the text before the selection
+ * 2. the selection
+ * These are slightly different depending on whether or not the comment is a block comment or a line comment, but can be simulated in the same way.
+ * 
+ * In the actual extension, these are determined with the vscode API, but here they are just simulated
+ */
+describe('isTagComment', function() {
+  it('should use cfscript comments in a cfscript-style component definition', function() {
+    let beforeText = `component {
+            this.name = "right"`;
+    let selectedText = `this.name = "commented"`;
+    assert.equal(isTagComment(beforeText, selectedText), false);
+  });
+  it('should use cfscript comments on line(s) within a <cfscript> tag in a tag-based file', function() {
+    let beforeText = `<cfoutput>something</cfoutput>
+            <cfscript>
+                line = "uncommented"`;
+    let selectedText = `line = "commented"`;
+    assert.equal(isTagComment(beforeText, selectedText), false);
+  });
+  it('should use tag comments in a tag-based file', function() {
+    let beforeText = `<cfoutput>
+            #myNewVar#`;
+    let selectedText = `#myOldVar#`;
+    assert.equal(isTagComment(beforeText, selectedText), true);
+  });
+  it('should use tag comments when text contains both script code and tag code', function() {
+    let beforeText = `<cfoutput>
+                <!--- #myOldVar# --->
+                #myNewVar#
+            </cfoutput>`;
+    let selectedText = `<cfscript>
+                no longer needed
+                myOldVar = 42
+            </cfscript>`;
+    assert.equal(isTagComment(beforeText, selectedText), true);
+  });
+  it('should use tag comments if the line(s) being commented include a <cfscript> opening or closing tag', function() {
+    let beforeText = `<cfoutput>`;
+    let selectedText = `<cfscript>notNecessary = true</cfscript>`;
+    assert.equal(isTagComment(beforeText, selectedText), true);
+  });
+
+  // This test currently fails, but is being added for documentation purposes
+  // Would be nice to get this working eventually
+  it.skip(
+    'should use cfscript comments on code within a <script> tag',
+    function() {
+      let beforeText = `<cfoutput><script>`;
+      let selectedText = `var el = document.getElementById('el')`;
+      assert.equal(
+        isTagComment(beforeText, selectedText),
+        true,
+        'used tag comments on javascript inside <script> tag'
+      );
+    }
+  );
+
+  // This test currently fails, but is being added for documentation purposes.
+  // Would be nice to get this working eventually
+  it.skip(
+    'should ignore commented-out cfscript tags when determining tag context',
+    function() {
+      let beforeText = `<!--- <cfscript --->`;
+      let selectedText = `myVar = 42`;
+      assert.equal(
+        isTagComment(beforeText, selectedText),
+        false,
+        'used cfscript comments even though the cfscript tag directly above was commented out'
+      );
+    }
+  );
+});

--- a/test/matchers.test.js
+++ b/test/matchers.test.js
@@ -1,14 +1,11 @@
-const assert = require('assert');
-const {
-  containsCFTag,
-  containsCFScriptTag,
-  isLastTagCFScript,
-  isTagComment
-} = require('../matchers');
+const {describe, it} = require('mocha')
+
+const assert = require("assert");
+const { containsCFTag, containsCFScriptTag, isLastTagCFScript, isTagComment } = require('../matchers');
 
 describe('containsCFTag', function() {
-  it('should return false if no <cf> tags exist', function() {
-    let string = `component {
+    it('should return false if no <cf> tags exist', function() {
+        let string = `component {
                         public void function foo() {
                             WriteOutput("Method foo() called<br/>");
                         }
@@ -18,25 +15,17 @@ describe('containsCFTag', function() {
                             return x;
                         }
                     }`;
-    assert.equal(
-      containsCFTag(string),
-      false,
-      'incorrectly found a <cf> tag in component definition'
-    );
+        assert.equal(containsCFTag(string), false, 'incorrectly found a <cf> tag in component definition');
 
-    string = `function Sum(a, b) {
+        string = `function Sum(a, b) {
             var sum = a + b;
             return sum;
         }`;
-    assert.equal(
-      containsCFTag(string),
-      false,
-      'incorrectly found a <cf> tag in function definition'
-    );
-  });
+        assert.equal(containsCFTag(string), false, 'incorrectly found a <cf> tag in function definition');
+    });
 
-  it('should return true if <cf> tags exist', function() {
-    let string = `<cfif IsDefined("form.myValue")> 
+    it('should return true if <cf> tags exist', function() {
+        let string = `<cfif IsDefined("form.myValue")> 
                         <cfif IsNumeric(form.myValue)> 
                             <cfset x = form.myValue> 
                             <cfscript> 
@@ -47,55 +36,39 @@ describe('containsCFTag', function() {
                         <cfoutput>        <p>twice #x# is #z#. 
                             <p>Your string value was: <b><I>#StringVar#</i></b>    </cfoutput> 
                     <cfelse>`;
-    assert.equal(containsCFTag(string), true, 'did not find <cf> tag');
-
-    string = `if IsNumeric(form.myValue)> 
+        assert.equal(containsCFTag(string), true, 'did not find <cf> tag')
+        
+        string = `if IsNumeric(form.myValue)> 
                     <cfs`;
-    assert.equal(
-      containsCFTag(string),
-      true,
-      'did not find <cf> tag in partial string'
-    );
+        assert.equal(containsCFTag(string), true, 'did not find <cf> tag in partial string');
 
-    string = `        <p>twice #x# is #z#. 
+        string = `        <p>twice #x# is #z#. 
         <p>Your string value was: <b><I>#StringVar#</i></b>    </cfoutput>`;
-    assert.equal(
-      containsCFTag(string),
-      true,
-      'did not find <cf> tag when only matching tags were closing tags'
-    );
-  });
-});
+        assert.equal(containsCFTag(string), true, 'did not find <cf> tag when only matching tags were closing tags');
+    });
+})
 
 describe('containsCFScriptTag', function() {
-  it('should return false if no cf tags are present', function() {
-    let string = `function Sum(a, b) {
+    it('should return false if no cf tags are present', function() {
+        let string = `function Sum(a, b) {
             var sum = a + b;
             return sum;
         }`;
-    assert.equal(
-      containsCFScriptTag(string),
-      false,
-      'incorrectly found a <cfscript> tag in function definition'
-    );
-  });
+        assert.equal(containsCFScriptTag(string), false, 'incorrectly found a <cfscript> tag in function definition');
+    });
 
-  it('should return false if cf tags are present but no cfscript', function() {
-    let string = `<cfif IsDefined("form.myValue")> 
+    it('should return false if cf tags are present but no cfscript', function() {
+        let string = `<cfif IsDefined("form.myValue")> 
                         <cfif IsNumeric(form.myValue)> 
                             <cfset x = form.myValue> 
                         <cfoutput>        <p>twice #x# is #z#. 
                             <p>Your string value was: <b><I>#StringVar#</i></b>    </cfoutput> 
                     <cfelse>`;
-    assert.equal(
-      containsCFScriptTag(string),
-      false,
-      'found a <cfscript> tag when none was present'
-    );
-  });
+        assert.equal(containsCFScriptTag(string), false, 'found a <cfscript> tag when none was present');
+    })
 
-  it('should return true if a cfscript tag is present', function() {
-    let string = `<cfif IsDefined("form.myValue")> 
+    it('should return true if a cfscript tag is present', function() {
+        let string = `<cfif IsDefined("form.myValue")> 
                         <cfif IsNumeric(form.myValue)> 
                             <cfset x = form.myValue> 
                             <cfscript> 
@@ -106,71 +79,43 @@ describe('containsCFScriptTag', function() {
                         <cfoutput>        <p>twice #x# is #z#. 
                             <p>Your string value was: <b><I>#StringVar#</i></b>    </cfoutput> 
                     <cfelse>`;
-    assert.equal(
-      containsCFScriptTag(string),
-      true,
-      'did not find <cfscript> tag in multi-line string'
-    );
+        assert.equal(containsCFScriptTag(string), true, 'did not find <cfscript> tag in multi-line string')
 
-    string = `<cfif IsDefined("form.myValue")> 
+        string = `<cfif IsDefined("form.myValue")> 
                 <cfif IsNumeric(form.myValue)> 
                     <cfset x = form.myValue> 
                     <cfscript> 
                         y = x;`;
-    assert.equal(
-      containsCFScriptTag(string),
-      true,
-      'did not find <cfscript> when no closing tag was present'
-    );
+        assert.equal(containsCFScriptTag(string), true, 'did not find <cfscript> when no closing tag was present')
 
-    string = `<cfif IsDefined("form.myValue")> <cfif IsNumeric(form.myValue)> <cfset x = form.myValue> <cfscript> y = x;`;
-    assert.equal(
-      containsCFScriptTag(string),
-      true,
-      'did not find <cfscript> in single line string'
-    );
+        string = `<cfif IsDefined("form.myValue")> <cfif IsNumeric(form.myValue)> <cfset x = form.myValue> <cfscript> y = x;`;
+        assert.equal(containsCFScriptTag(string), true, 'did not find <cfscript> in single line string')
 
-    string = `<cfscript>`;
-    assert.equal(
-      containsCFScriptTag(string),
-      true,
-      'did not find <cfscript> when that was the entire string'
-    );
-  });
+        string = `<cfscript>`;
+        assert.equal(containsCFScriptTag(string), true, 'did not find <cfscript> when that was the entire string');
+    })
 
-  it('should return true if a closing cfscript tag is present', function() {
-    string = `y = x; 
+    it('should return true if a closing cfscript tag is present', function() {
+        string = `y = x; 
                         z = 2 * y; 
                         StringVar = form.myString; 
                     </cfscript> 
                 <cfoutput>        <p>twice #x# is #z#. 
                     <p>Your string value was: <b><I>#StringVar#</i></b>    </cfoutput> 
                 <cfelse>`;
-    assert.equal(
-      containsCFScriptTag(string),
-      true,
-      'did not find </cfscript> when no opening tag was present'
-    );
+        assert.equal(containsCFScriptTag(string), true, 'did not find </cfscript> when no opening tag was present')
 
-    string = `y = x; z = 2 * y; StringVar = form.myString; </cfscript><cfoutput> <p>twice #x# is #z#. </cfoutput> <cfelse>`;
-    assert.equal(
-      containsCFScriptTag(string),
-      true,
-      'did not find </cfscript> in single line string'
-    );
+        string = `y = x; z = 2 * y; StringVar = form.myString; </cfscript><cfoutput> <p>twice #x# is #z#. </cfoutput> <cfelse>`;
+        assert.equal(containsCFScriptTag(string), true, 'did not find </cfscript> in single line string')
 
-    string = `</cfscript>`;
-    assert.equal(
-      containsCFScriptTag(string),
-      true,
-      'did not find </cfscript> when that was the entire string'
-    );
-  });
-});
+        string = `</cfscript>`;
+        assert.equal(containsCFScriptTag(string), true, 'did not find </cfscript> when that was the entire string');
+    })
+})
 
 describe('isLastTagCFScript', function() {
-  it('should return false when cfscript tag is not the last tag in the string', function() {
-    let string = `<cfscript>
+    it('should return false when cfscript tag is not the last tag in the string', function() {
+        let string = `<cfscript>
                     y = x; 
                     z = 2 * y; 
                     StringVar = form.myString; 
@@ -178,53 +123,33 @@ describe('isLastTagCFScript', function() {
             <cfoutput>        <p>twice #x# is #z#. 
                 <p>Your string value was: <b><I>#StringVar#</i></b>    </cfoutput> 
             <cfelse>`;
-    assert.equal(
-      isLastTagCFScript(string),
-      false,
-      'it thought that <cfelse> was a <cfscript> tag'
-    );
+        assert.equal(isLastTagCFScript(string), false, 'it thought that <cfelse> was a <cfscript> tag');
 
-    string = `<cfscript>
+        string = `<cfscript>
                     y = x; 
                     z = 2 * y; 
                     StringVar = form.myString; 
                 </cfscript>`;
-    assert.equal(
-      isLastTagCFScript(string),
-      false,
-      'it thought that a closing </cfscript> tag was an opening <cfscript> tag'
-    );
-  });
-  it('should return true when cfscript is the last tag in the string', function() {
-    let string = `<cfscript>
+        assert.equal(isLastTagCFScript(string), false, 'it thought that a closing </cfscript> tag was an opening <cfscript> tag');
+    })
+    it('should return true when cfscript is the last tag in the string', function() {
+        let string = `<cfscript>
                     y = x; 
                     z = 2 * y; 
                     StringVar = form.myString; `;
-    assert.equal(
-      isLastTagCFScript(string),
-      true,
-      'did not recognize the last tag as cfscript when cfscript is the only tag present'
-    );
+        assert.equal(isLastTagCFScript(string), true, 'did not recognize the last tag as cfscript when cfscript is the only tag present');
 
-    string = `<cfif IsDefined("form.myValue")> 
+        string = `<cfif IsDefined("form.myValue")> 
             <cfif IsNumeric(form.myValue)> 
                 <cfset x = form.myValue> 
                 <cfscript> 
-                    y = x; `;
-    assert.equal(
-      isLastTagCFScript(string),
-      true,
-      'did not recognize last tag as cfscript when other tags exist above it'
-    );
+                    y = x; `
+        assert.equal(isLastTagCFScript(string), true, 'did not recognize last tag as cfscript when other tags exist above it');
 
-    string = `<cfscript>`;
-    assert.equal(
-      isLastTagCFScript(string),
-      true,
-      'failed to recognize the string "<cfscript>" as the last cf tag'
-    );
-  });
-});
+        string = `<cfscript>`;
+        assert.equal(isLastTagCFScript(string), true, 'failed to recognize the string "<cfscript>" as the last cf tag');
+    })
+})
 
 /**
  * Each test case in this suite should be passed two strings:
@@ -235,69 +160,158 @@ describe('isLastTagCFScript', function() {
  * In the actual extension, these are determined with the vscode API, but here they are just simulated
  */
 describe('isTagComment', function() {
-  it('should use cfscript comments in a cfscript-style component definition', function() {
-    let beforeText = `component {
-            this.name = "right"`;
-    let selectedText = `this.name = "commented"`;
-    assert.equal(isTagComment(beforeText, selectedText), false);
-  });
-  it('should use cfscript comments on line(s) within a <cfscript> tag in a tag-based file', function() {
-    let beforeText = `<cfoutput>something</cfoutput>
-            <cfscript>
-                line = "uncommented"`;
-    let selectedText = `line = "commented"`;
-    assert.equal(isTagComment(beforeText, selectedText), false);
-  });
-  it('should use tag comments in a tag-based file', function() {
-    let beforeText = `<cfoutput>
+    it('should use cfscript comments in a cfscript-style component definition', function() {
+        let docText = `component {
+            public void function foo() {
+                WriteOutput("Method foo() called<br/>");
+            }
+
+            public function getString() {
+                var x = "hello";
+                return x;
+            }
+        }`
+        let beforeText = `component {
+            public void function foo() {`;
+        let selectedText = `WriteOutput("Method foo() called<br/>");`;
+        let line = 3;
+        assert.equal(isTagComment(docText, beforeText, selectedText, line), false);
+    })
+    it('should use cfscript comments on line(s) within a <cfscript> tag in a tag-based file', function() {
+        let docText = `<cfif IsDefined("form.myValue")> 
+        <cfif IsNumeric(form.myValue)> 
+            <cfset x = form.myValue> 
+            <cfscript> 
+                y = x; 
+                z = 2 * y; 
+                StringVar = form.myString; 
+            </cfscript> 
+        <cfoutput>        <p>twice #x# is #z#. 
+            <p>Your string value was: <b><I>#StringVar#</i></b>    </cfoutput> 
+    <cfelse>`;
+        let beforeText = `<cfif IsDefined("form.myValue")> 
+        <cfif IsNumeric(form.myValue)> 
+            <cfset x = form.myValue> 
+            <cfscript> 
+                y = x; 
+                z = 2 * y; `;
+        let selectedText = `StringVar = form.myString; `;
+        let line = 7;
+        assert.equal(isTagComment(docText, beforeText, selectedText, line), false);
+    })
+    it('should use tag comments in a tag-based file', function() {
+        let docText = `<cfif IsDefined("form.myValue")> 
+        <cfif IsNumeric(form.myValue)> 
+            <cfset x = form.myValue> 
+            <cfscript> 
+                y = x; 
+                z = 2 * y; 
+                StringVar = form.myString; 
+            </cfscript> 
+        <cfoutput>        <p>twice #x# is #z#. 
+            <p>Your string value was: <b><I>#StringVar#</i></b>    </cfoutput> 
+    <cfelse>`;
+        let beforeText = `<cfoutput>
             #myNewVar#`;
-    let selectedText = `#myOldVar#`;
-    assert.equal(isTagComment(beforeText, selectedText), true);
-  });
-  it('should use tag comments when text contains both script code and tag code', function() {
-    let beforeText = `<cfoutput>
+        let selectedText = `#myOldVar#`;
+        let line = 8;
+        assert.equal(isTagComment(docText, beforeText, selectedText, line), true);
+    })
+    it('should use tag comments when text contains both script code and tag code', function() {
+        let docText = `<cfif IsDefined("form.myValue")> 
+        <cfif IsNumeric(form.myValue)> 
+            <cfset x = form.myValue> 
+            <cfscript> 
+                y = x; 
+                z = 2 * y; 
+                StringVar = form.myString; 
+            </cfscript> 
+        <cfoutput>        <p>twice #x# is #z#. 
+            <p>Your string value was: <b><I>#StringVar#</i></b>    </cfoutput> 
+    <cfelse>`;
+        let beforeText = `<cfoutput>
                 <!--- #myOldVar# --->
                 #myNewVar#
             </cfoutput>`;
-    let selectedText = `<cfscript>
-                no longer needed
-                myOldVar = 42
-            </cfscript>`;
-    assert.equal(isTagComment(beforeText, selectedText), true);
-  });
-  it('should use tag comments if the line(s) being commented include a <cfscript> opening or closing tag', function() {
-    let beforeText = `<cfoutput>`;
-    let selectedText = `<cfscript>notNecessary = true</cfscript>`;
-    assert.equal(isTagComment(beforeText, selectedText), true);
-  });
+        let selectedText = `<cfscript> 
+        y = x; 
+        z = 2 * y; 
+        StringVar = form.myString; 
+    </cfscript>`;
+        let line = 4;
+        assert.equal(isTagComment(docText, beforeText, selectedText, line), true);
+    })
+    it('should use tag comments if the line(s) being commented include a <cfscript> opening or closing tag', function() {
+        let docText = `<cfif IsDefined("form.myValue")> 
+        <cfif IsNumeric(form.myValue)> 
+            <cfset x = form.myValue> 
+            <cfscript>notNecessary = true</cfscript>
+        <cfoutput>        <p>twice #x# is #z#. 
+            <p>Your string value was: <b><I>#StringVar#</i></b>    </cfoutput> 
+    <cfelse>`;
+        let beforeText = `<cfif IsDefined("form.myValue")> 
+        <cfif IsNumeric(form.myValue)> 
+            <cfset x = form.myValue> `;
+        let selectedText = `<cfscript>notNecessary = true</cfscript>`;
+        let line = 4;
+        assert.equal(isTagComment(docText, beforeText, selectedText, line), true);
+    })
 
-  // This test currently fails, but is being added for documentation purposes
-  // Would be nice to get this working eventually
-  it.skip(
-    'should use cfscript comments on code within a <script> tag',
-    function() {
-      let beforeText = `<cfoutput><script>`;
-      let selectedText = `var el = document.getElementById('el')`;
-      assert.equal(
-        isTagComment(beforeText, selectedText),
-        true,
-        'used tag comments on javascript inside <script> tag'
-      );
-    }
-  );
+    it('should use tag comments if file contains cftags and comment is on first line', function() {
+        let docText = `
+        <cfif IsDefined("form.myValue")> 
+        <cfif IsNumeric(form.myValue)> 
+            <cfset x = form.myValue> 
+            <cfscript>notNecessary = true</cfscript>
+        <cfoutput>        <p>twice #x# is #z#. 
+            <p>Your string value was: <b><I>#StringVar#</i></b>    </cfoutput> 
+        <cfelse>`;
+        let beforeText = ``;
+        let selectedText = ``;
+        let line = 0;
+        assert.equal(isTagComment(docText, beforeText, selectedText, line), true);
+    })
 
-  // This test currently fails, but is being added for documentation purposes.
-  // Would be nice to get this working eventually
-  it.skip(
-    'should ignore commented-out cfscript tags when determining tag context',
-    function() {
-      let beforeText = `<!--- <cfscript --->`;
-      let selectedText = `myVar = 42`;
-      assert.equal(
-        isTagComment(beforeText, selectedText),
-        false,
-        'used cfscript comments even though the cfscript tag directly above was commented out'
-      );
-    }
-  );
-});
+    // This test currently fails, but is being added for documentation purposes
+    // Would be nice to get this working eventually
+    it.skip('should use cfscript comments on code within a <script> tag', function() {
+        let docText = `<cfif IsDefined("form.myValue")> 
+        <cfif IsNumeric(form.myValue)> 
+            <cfset x = form.myValue> 
+            <script> 
+                var y = x; 
+                var z = 2 * y; 
+                var el = document.getElementById('el')
+            </script> 
+        <cfoutput>        <p>twice #x# is #z#. 
+            <p>Your string value was: <b><I>#StringVar#</i></b>    </cfoutput> 
+    <cfelse>`;
+        let beforeText = `<cfif IsDefined("form.myValue")> 
+        <cfif IsNumeric(form.myValue)> 
+            <cfset x = form.myValue> <script>`;
+        let selectedText = `var el = document.getElementById('el')`;
+        let line = 8;
+        assert.equal(isTagComment(docText, beforeText, selectedText, line), true, 'used tag comments on javascript inside <script> tag');
+    })
+
+    // This test currently fails, but is being added for documentation purposes.
+    // Would be nice to get this working eventually
+    it.skip('should ignore commented-out cfscript tags when determining tag context', function() {
+        let docText = `<cfif IsDefined("form.myValue")> 
+        <cfif IsNumeric(form.myValue)> 
+            <cfset x = form.myValue> 
+            <!--- <cfscript> --->
+                notNecessary = true
+            <!--- </cfscript> --->
+        <cfoutput>        <p>twice #x# is #z#. 
+            <p>Your string value was: <b><I>#StringVar#</i></b>    </cfoutput> 
+    <cfelse>`;
+        let beforeText = `<cfif IsDefined("form.myValue")> 
+        <cfif IsNumeric(form.myValue)> 
+            <cfset x = form.myValue> 
+            <!--- <cfscript> --->`;
+        let selectedText = `notNecessary = true`;
+        let line = 5;
+        assert.equal(isTagComment(docText, beforeText, selectedText, line), false, 'used cfscript comments even though the cfscript tag directly above was commented out');
+    })  
+})


### PR DESCRIPTION
Per #23, the commenting in this extension does not work correctly.  Removing the line comment property from the language configuration fixes this issue and allows the standard `ctrl+/` key binding to work correctly for CFML files.

This would close #18 and addresses concerns raised in #15.