### PR TITLE
Simple fix for single line comments

### DIFF
--- a/cfscript.configuration.json
+++ b/cfscript.configuration.json
@@ -1,6 +1,5 @@
 {
 	"comments": {
-		"lineComment": [ "<!---", "--->" ],
 		"blockComment": [ "<!---", "--->" ]
 	},
 	"brackets": [

--- a/package.json
+++ b/package.json
@@ -21,14 +21,14 @@
 	],
 	"contributes": {
 		"languages": [
-			{ "id": "lang-cfml", "aliases": ["CFML"], "extensions": [".cfm",".cfml",".cfc"], "configuration": "./cfscript.configuration.json"}
+			{ "id": "cfml", "aliases": ["CFML"], "extensions": [".cfm",".cfml",".cfc"], "configuration": "./cfscript.configuration.json"}
 		],
 		"grammars": [
-			{"language": "lang-cfml", "scopeName": "embedding.cfml", "path": "./syntaxes/cfml.tmLanguage" }
+			{"language": "cfml", "scopeName": "embedding.cfml", "path": "./syntaxes/cfml.tmLanguage" }
 		],
 		"snippets": [
 			{
-				"language": "lang-cfml",
+				"language": "cfml",
 				"path": "./snippets/snippets.json"
 			}
 		]


### PR DESCRIPTION
Fix single line comments.
Change grammar to be more intuitive. 

For example, when using Beautify I tried adding ColdFusion to the list, but I couldn't understand why "cfml" didn't work. I thought it was just broken but I just didn't realize I had to use "lang-cfml."