### PR TITLE
Update line comments for tag syntax

### DIFF
--- a/src/editor/commands/LineCommentCommand.ts
+++ b/src/editor/commands/LineCommentCommand.ts
@@ -20,8 +20,6 @@ export class LineCommentCommand implements ICommand {
             position = line.range.start;
         }
 
-        let executeCommand = true;
-        const command = "editor.action.commentLine";
         let config: vscode.LanguageConfiguration = {
             comments: {
                 lineComment: "//",
@@ -37,18 +35,14 @@ export class LineCommentCommand implements ICommand {
             };
         } else if (!context.isScript(position)) {
             // it is not a cfquery or cfscript or script tag
-            // apply cfml comment manually
-            executeCommand = false;
-            editor.edit((builder: vscode.TextEditorEdit) => {
-                const range = line.range;
-                builder.insert(range.start, "<!--- ");
-                builder.insert(range.end, " --->");
-            });
+            config = {
+                comments: {
+                    blockComment: ["<!---", "--->"],
+                },
+            };
         }
 
-        if (executeCommand) {
-            vscode.languages.setLanguageConfiguration(LANGUAGE_ID, config);
-            vscode.commands.executeCommand(command);
-        }
+        vscode.languages.setLanguageConfiguration(LANGUAGE_ID, config);
+        vscode.commands.executeCommand("editor.action.commentLine");
     }
 }


### PR DESCRIPTION
Nice updates to this extension. The new structure and logic is really good.

I noticed a bug with line comments in tag syntax. Since it just manually inserts the text, the line toggle command does not actually toggle a line comment - it simply adds more `<!--- --->` around the block.

I've made an update based on what I did in my [first pull request](https://github.com/ilich/vscode-coldfusion/pull/24) which makes line commenting toggle properly.